### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the missing **GitHub Skills** extracurricular activity that was announced by the principal.

## Changes
- Added "GitHub Skills" to the activities dictionary in `app.py`
- Description references the GitHub Certifications program to help with college applications
- Schedule: Mondays and Wednesdays, 3:30 PM - 5:00 PM
- Max participants: 25 (to accommodate expected high demand)
- Currently has 0 participants (ready for registration)

## Resolves
Fixes #6 

## Testing
- ✅ Python syntax validation passed
- ✅ Activity will appear in the activities list on the website
- ✅ Students can now register for the GitHub Skills activity before the end-of-week deadline

## Priority
🚨 **Time-sensitive** - Registration deadline is end of this week as mentioned in the issue.